### PR TITLE
Fix transaction balance update logic

### DIFF
--- a/finverse_api/app/services/transaction_service.py
+++ b/finverse_api/app/services/transaction_service.py
@@ -147,10 +147,18 @@ class TransactionService(FinancialService[Transaction, CreateTransactionSchema, 
             current_balance = Decimal(str(current_balance))
         
         # Apply transaction based on type with Decimal arithmetic
-        if transaction_type == 1:  # Income - add to balance
+        # TransactionType enum uses 0 for INCOME and 1 for EXPENSE
+        if transaction_type == TransactionType.INCOME.value:
+            # Income - add to balance
             new_balance = current_balance + amount_decimal
-        else:  # Expense - subtract from balance
+        elif transaction_type == TransactionType.EXPENSE.value:
+            # Expense - subtract from balance
             new_balance = current_balance - amount_decimal
+        else:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid transaction type"
+            )
             
         # Validate balance
         if new_balance < 0:


### PR DESCRIPTION
## Summary
- fix balance update logic in `TransactionService.update_account_balance`
- validate transaction type using enum values

## Testing
- `pytest -q finverse_api/tests/test_transaction_service.py` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_b_6853878798ec832f88980497746841e7