### PR TITLE
Fix alembic tz dependency comment

### DIFF
--- a/finverse_api/alembic.ini
+++ b/finverse_api/alembic.ini
@@ -18,7 +18,7 @@ prepend_sys_path = .
 # timezone to use when rendering the date within the migration file
 # as well as the filename.
 # If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
-# Any required deps can installed by adding `alembic[tz]` to the pip requirements
+# Any required dependencies can be installed by adding "alembic[tz]" to the pip requirements
 # string value is passed to ZoneInfo()
 # leave blank for localtime
 # timezone =


### PR DESCRIPTION
## Summary
- update alembic.ini to fix wording about tz dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_685389dfac34832f84c3f3c2215f4400