### PR TITLE
Clean up staking test file

### DIFF
--- a/finverse_api/tests/test_staking_service.py
+++ b/finverse_api/tests/test_staking_service.py
@@ -77,9 +77,3 @@ def test_get_staking_pools_response_has_contract_addresses():
         assert isinstance(pool.token_address, str)
         assert len(pool.token_address) == 42
         assert pool.token_address.startswith('0x')
-
-if __name__ == "__main__":
-    # Run basic test
-    test_mock_pools_have_contract_addresses()
-    test_ethereum_address_validation()
-    print("✅ All tests passed!") 


### PR DESCRIPTION
## Summary
- remove standalone execution block from `test_staking_service.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_685389ded304832faf170cca685fa576